### PR TITLE
Feature/add ajax showtime and banned word list

### DIFF
--- a/src/lists/authorWhitelist.json
+++ b/src/lists/authorWhitelist.json
@@ -1,13 +1,16 @@
-{"whitelistHandles": [
-  "ajaxpro.bsky.social",
-  "pakschaal.bsky.social",
-  "allaboutajax.bsky.social",
-  "vanpogototpopo.bsky.social",
-  "pantelicpodcast.bsky.social",
-  "ajaxnewszone.bsky.social",
-  "ajaxlife.bsky.social",
-  "ajaxventos.bsky.social",
-  "afc-ajax.bsky.social",
-  "ajaxya.bsky.social",
-  "braniedepodcast.bsky.social"
-]}
+{
+  "whitelistHandles": [
+    "ajaxpro.bsky.social",
+    "pakschaal.bsky.social",
+    "allaboutajax.bsky.social",
+    "vanpogototpopo.bsky.social",
+    "pantelicpodcast.bsky.social",
+    "ajaxnewszone.bsky.social",
+    "ajaxlife.bsky.social",
+    "ajaxventos.bsky.social",
+    "afc-ajax.bsky.social",
+    "ajaxya.bsky.social",
+    "braniedepodcast.bsky.social",
+    "ajaxshowtimecom.bsky.social"
+  ]
+}

--- a/src/lists/bannedWordList.json
+++ b/src/lists/bannedWordList.json
@@ -1,0 +1,7 @@
+{
+  "bannedWords": [
+    // Een lijst met woorden die voor vreemde toevoegingen zorgen in de feed.
+    "motorcycle",
+    "hubbard"
+  ]
+}

--- a/src/subscription.ts
+++ b/src/subscription.ts
@@ -9,7 +9,7 @@ import fetch from 'node-fetch';
 
 // Set the allowed languages for the language detector.
 const lngDetector = new LanguageDetect();
-const allowedLanguages = ['dutch']
+const allowedLanguages = ['dutch', 'english'] // Maybe add english content as well?
 
 // Set the minimum number of likes for an Ajax post that is written by an author that is not
 // on the gray or whitelist.
@@ -23,7 +23,7 @@ const handleResolveUrl = 'https://bsky.social/xrpc/com.atproto.identity.resolveH
 import authorWhitelist from "./lists/authorWhitelist.json"
 import authorGreylist from "./lists/authorGreylist.json"
 import ajaxHitWords from "./lists/ajaxHitWords.json"
-
+import bannedWordList from "./lists/bannedWordList.json"
 // Fetch the user DIDs from the given user handles.
 type UserDid = {
   did: string
@@ -71,8 +71,11 @@ export class FirehoseSubscription extends FirehoseSubscriptionBase {
 
         // Add Ajax posts to the post store if they include words from the Ajax hit list and if they
         // are not authored by an author on the greylist or whitelist.
+        // Added filter for known words that add posts to the feed that aren't Ajax related.
         if (ajaxHitWords.hitWords.some(hitWord => create.record.text.toLowerCase().includes(hitWord)) &&
-            allowedLanguages.includes(lngDetector.detect(create.record.text, 1)[0][0])) {
+            allowedLanguages.includes(lngDetector.detect(create.record.text, 1)[0][0]) &&
+            !bannedWordList.bannedWords.some(bannedWord => create.record.text.toLowerCase().includes(bannedWord)))
+          {
           postStore.set(create.uri, 0)
         }
 


### PR DESCRIPTION
Kleine toevoeging naar aanleiding van dit weekend. 

Misschien is het het overwegen waard om momenteel de like requirement even uit te schakelen? Zo krijg je hopelijk wat meer content tijdens de wedstrijden van users, en kunnen we elkaar ook wat makkelijker vinden? Misschien even deze week aankijken en dan kun je het altijd weer opschalen.

Ik had ook een idee voor de hitWords, denk dat het opzich makkelijker bijhouden is als er wat meer orde wordt aangebracht? Specifieke lijsten voor bijvoorbeeld spelers / staff / media, zo is het makkelijker bij te houden en hoef je niet door een array van 300 woorden te gaan zoeken naar een specieke speler bijvoorbeeld? Kunnen we in de toekomst ook eventueel nog bepaalde waardes aan verschillende lijsten hangen (Spelers 1.0, jeugd 0.8 bijvoorbeeld).

